### PR TITLE
Add copy-on-write support for BTRFS filesystem

### DIFF
--- a/shutil.go
+++ b/shutil.go
@@ -127,6 +127,10 @@ func CopyFile(src, dst string, followSymlinks bool) (error) {
   }
   defer fdst.Close()
 
+  if success, _ := clonefile(fdst, fsrc); success {
+    return nil
+  }
+
   size, err := io.Copy(fdst, fsrc)
   if err != nil {
     return err

--- a/shutil_generic.go
+++ b/shutil_generic.go
@@ -1,0 +1,11 @@
+// +build !linux !cgo
+
+package shutil
+
+import (
+	"os"
+)
+
+func clonefile(fdst *os.File, fsrc *os.File) (bool, error) {
+	return false, nil
+}

--- a/shutil_linux.go
+++ b/shutil_linux.go
@@ -1,0 +1,29 @@
+// +build linux,cgo
+
+package shutil
+
+/*
+#include <sys/ioctl.h>
+
+#undef BTRFS_IOCTL_MAGIC
+#define BTRFS_IOCTL_MAGIC 0x94
+#undef BTRFS_IOC_CLONE
+#define BTRFS_IOC_CLONE _IOW (BTRFS_IOCTL_MAGIC, 9, int)
+*/
+import "C"
+
+import (
+	"os"
+	"syscall"
+)
+
+const (
+	BtrfsIocClone = C.BTRFS_IOC_CLONE
+)
+
+func clonefile(fdst *os.File, fsrc *os.File) (bool, error) {
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fdst.Fd(), BtrfsIocClone, fsrc.Fd()); err != 0 {
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
After this change CopyFile try make copy-on-write (constant time) file copy on BTRFS filesystem.
If copy-on-write operation is not supported - failback to byte-to-byte file copy.

This command works like:

```
cp --reflink=auto src.txt dst.txt
```

For this change I use https://github.com/wertarbyte/coreutils/blob/master/src/copy.c as reference.
